### PR TITLE
feat(openapi): add support for openapi refs and path parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,4 @@ generated/
 
 # MacOS
 .DS_Store
+.aider*

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ No install required — just run the generator directly from GitHub:
 ```bash
 uvx https://github.com/cnoe-io/openapi-mcp-codegen.git -- generate \
   --spec-file examples/openapi_petstore.json \
-  --output-dir examples/mcp_petstore
+  --output-dir examples/mcp_petstore \
   --enhance-docstring-with-llm-openapi
 ```
 

--- a/openapi_mcp_codegen/templates/server.tpl
+++ b/openapi_mcp_codegen/templates/server.tpl
@@ -48,7 +48,7 @@ def main():
 {% for module, ops in registrations.items() %}
     # Register {{ module }} tools
 {% for op in ops %}
-    mcp.tool()({{ module }}.{{ op }})
+    mcp.tool()({{ module }}.{{ op | replace('{', '') | replace('}', '') }})
 {% endfor %}{% endfor %}
 
     # Run the MCP server


### PR DESCRIPTION
# Description

Build HTTP parameters by prefixing them in the tool with `path_` and `body_` to translate them back when making the API call.

* Implement openapi $ref to json translation
* Support for path and body parameters
* Initial doc string pass from OpenAPI spec then run enhancement in parallel


## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
